### PR TITLE
Initialise TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+language: node_js
+node_js:
+  - '0.10'
+cache:
+  directories:
+    - node_modules
+    - bower_components
+before_install:
+  - echo "machine github.com login $CI_USER_TOKEN" >> ~/.netrc
+notifications:
+  flowdock:
+    secure: rVJ5bSorZpx6hz446jMJfu3WnsIZvSTHic1y86EZpI7ORfHtXZLdinI6g7sRIJQC1guvTbWybbVEdHCHQ1wo2AjnbCokfO0PXpOZssuwgyc5ENuO3OWBX5ofse00Ay+RVqyNQCwArUqmz3jPZXGnjTpf6k3jNHq+C2JH7dWbrzM=

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # direct-delivery
 
+[![Build Status][travis-image]][travis-url]
+
+[travis-url]: https://travis-ci.org/eHealthAfrica/direct-delivery
+[travis-image]: https://travis-ci.org/eHealthAfrica/direct-delivery.svg?branch=master
+
 > User-centred direct delivery management system
 
 ## Usage
 
 0. Install [Node.js][] and [Git][]
-1. `npm install -g karma gulp bower`
+1. `npm install -g gulp bower`
 2. `git clone https://github.com/eHealthAfrica/direct-delivery.git`
 3. `cd direct-delivery && npm install; bower install`
 4. `gulp serve`

--- a/package.json
+++ b/package.json
@@ -3,16 +3,17 @@
   "version": "1.0.0",
   "dependencies": {},
   "devDependencies": {
+    "bower": "^1.3.12",
     "browser-sync": "~1.7.1",
     "chalk": "~0.5.1",
     "couch-compile": "^1.2.0",
-    "data_model": "git+ssh://git@github.com:eHealthAfrica/data_model.git",
+    "data-model": "git+https://github.com/eHealthAfrica/data_model.git#1.2.2",
     "del": "~0.1.3",
     "eslint": "^0.10.1",
     "extend": "^2.0.0",
     "favicons": "^1.5.3",
     "got": "^2.2.0",
-    "gulp": "~3.8.10",
+    "gulp": "^3.8.10",
     "gulp-angular-filesort": "^1.0.4",
     "gulp-angular-templatecache": "~1.4.2",
     "gulp-autoprefixer": "~2.0.0",
@@ -51,6 +52,7 @@
   "description": "User-centred direct delivery management system",
   "main": "gulpfile.js",
   "scripts": {
+    "postinstall": "bower install",
     "test": "gulp test"
   },
   "repository": {


### PR DESCRIPTION
* Makes use of TravisCI's Docker stack and caching
* Adds `gulp` and `bower` as local dependencies so `npm test` "just works"

**Note**: since we have a private dependency (`data-model`), I've generated an API token (for my GitHub account) so that TravisCI can pull the dependency as described in the [API Token recipe](http://docs.travis-ci.com/user/private-dependencies/#API-Token). Penned to be replaced with a dedicated CI account, or open sourcing data-model.

**Note**: TravisCI will report as failed as we don't have any tests (yet).