### PR TITLE
Use angular-pouchdb on Bower registry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "pouchdb-authentication": "~0.3.6",
     "asmcrypto": "~0.0.6",
     "lodash": "~2.4.1",
-    "angular-pouchdb": "angular-pouchdb/angular-pouchdb#~1.0.2"
+    "angular-pouchdb": "~1.0.2"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.4"


### PR DESCRIPTION
It has been published on the registry, so we don't need to rely on a GitHub link.