### PR TITLE
Disable Travis builds on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
     - bower_components
 before_install:
   - echo "machine github.com login $CI_USER_TOKEN" >> ~/.netrc
+script:
+  - ./travis/script.sh
 after_script:
   - npm run coveralls
 notifications:

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+error() { echo "$0: $1"; exit 1; }
+
+[[ "$TRAVIS" ]] || error "this script assumes it's running within TravisCI"
+[[ "$TRAVIS_PULL_REQUEST" == "false" ]] || error "pull request builds disabled"
+
+npm test


### PR DESCRIPTION
The `CI_USER_TOKEN` environment variable is disabled on pull requests, so is
never set and hangs the build (until it times out).

Therefore, disable builds on pull requests entirely until we can remove the
single private dependency (`data_model`; soon to be open sourced).

See: http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests