### PR TITLE
Move ui.bootstrap into core

### DIFF
--- a/src/app/home/home.module.js
+++ b/src/app/home/home.module.js
@@ -1,6 +1,5 @@
 'use strict';
 
 angular.module('home', [
-  'core',
-  'ui.bootstrap'
+  'core'
 ]);

--- a/src/app/packing/item/item.module.js
+++ b/src/app/packing/item/item.module.js
@@ -2,6 +2,5 @@
 
 angular.module('packing.item', [
   'core',
-  'ui.bootstrap',
   'couchdb'
 ]);

--- a/src/components/core/core.module.js
+++ b/src/components/core/core.module.js
@@ -2,4 +2,5 @@
 
 angular.module('core', [
   'ui.router',
+  'ui.bootstrap'
 ]);


### PR DESCRIPTION
It'd be nice to explicitly list each ui.bootstrap.* per module that depends on
one, but this will pull in ui-bootstrap-tpls.js, which contains the entire
ui-bootstrap suite anyway, negating any benefits we'd get from enumerating each
dependency.

The alternative would be to add Bower shim repos per ui-boostrap module that we
depend on (upstream provide a custom build tool, but not separate Bower repos),
but it's probably more of a maintenance burden than its worth.