### PR TITLE
Overwrite fixtures and views on subsequent pushes

### DIFF
--- a/gulp/couchdb.js
+++ b/gulp/couchdb.js
@@ -20,12 +20,15 @@ if (argv.u && argv.p) {
 dbUrl = url.format(dbUrl);
 
 function push(docs) {
-  docs = JSON.stringify({
-    docs: docs
+  var body = JSON.stringify({
+    docs: docs,
+    /*eslint-disable camelcase */
+    all_or_nothing: true
+    /*eslint-enable camelcase */
   });
 
   var options = {
-    body: docs,
+    body: body,
     headers: {
       'Content-Type': 'application/json'
     }


### PR DESCRIPTION
Since we're using Git to version fixtures and views, we're not concerned about
CouchDB revisions.

Therefore, overwrite fixtures and views each time `gulp views` or `gulp
fixtures` is ran.

See [bulk docs all-or-nothing][1] semantics.

[1]: http://docs.couchdb.org/en/1.6.1/api/database/bulk-api.html#bulk-documents-transaction-semantics