### PR TITLE
Prep angular-pouchdb for persist plugin

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,11 +13,12 @@
     "pouchdb-authentication": "~0.3.6",
     "asmcrypto": "~0.0.6",
     "lodash": "~2.4.1",
-    "angular-pouchdb": "~1.0.2",
+    "angular-pouchdb": "~2.0.0-rc.1",
     "signature_pad": "~1.3.4",
     "angular-resource": "~1.3.6",
     "angular-bootstrap": "~0.12.0",
-    "angular-ui-router-tabs": "~1.1.4"
+    "angular-ui-router-tabs": "~1.1.4",
+    "pouchdb-persist": "~0.0.6"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.4",

--- a/src/components/auth/auth.config.js
+++ b/src/components/auth/auth.config.js
@@ -1,10 +1,12 @@
 'use strict';
 
 angular.module('auth')
-  .config(function(pouchDBProvider, POUCHDB_DEFAULT_METHODS) {
-    pouchDBProvider.methods = POUCHDB_DEFAULT_METHODS.concat([
-      'login',
-      'logout',
-      'getUser'
-    ]);
+  .config(function(pouchDBProvider, POUCHDB_METHODS) {
+    var loginMethods = {
+      login: 'qify',
+      logout: 'qify',
+      getUser: 'qify'
+    };
+
+    pouchDBProvider.methods = angular.extend({}, POUCHDB_METHODS, loginMethods);
   });

--- a/src/index.html
+++ b/src/index.html
@@ -39,6 +39,7 @@
     <script src="../bower_components/angular-resource/angular-resource.js"></script>
     <script src="../bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
     <script src="../bower_components/angular-ui-router-tabs/src/ui-router-tabs.js"></script>
+    <script src="../bower_components/pouchdb-persist/dist/pouchdb-persist.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 


### PR DESCRIPTION
@jofomah, `pouchdb-persist` should work now. With the new set up in
`angular-pouchdb`, you have to tell it which methods you want wrapped with the
name of the corresponding decorator function (in `pouchDecorators`) in a `config`
block. See `auth.config.js` for an example (using the `pouchdb-auth` plugin).

In the case of `pouchdb-persist`, it seems to declare an event emitter on the
`.persist` method, so the config might look something like:

```js
var persistMethods = {
  persist: 'eventEmitter'
};
```

You might need to experiment with this; make sure that `auth`s wrappings aren't
overwritten, or perhaps you don't need to wrap any of `pouchdb-persist`s
methods at all.