### PR TITLE
Drop LoDash

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,6 @@
     "pouchdb": "~3.3.0",
     "pouchdb-authentication": "~0.3.6",
     "asmcrypto": "~0.0.6",
-    "lodash": "~2.4.1",
     "angular-pouchdb": "~2.0.0-rc.1",
     "signature_pad": "~1.3.4",
     "angular-bootstrap": "~0.12.0",
@@ -30,9 +29,6 @@
   "overrides": {
     "bootstrap-sass-official": {
       "dependencies": []
-    },
-    "lodash": {
-      "main": "dist/lodash.js"
     }
   },
   "authors": [

--- a/src/components/auth/auth.service.js
+++ b/src/components/auth/auth.service.js
@@ -1,7 +1,7 @@
 'use strict';
 
-(function() {
-  function AuthService($rootScope, $window, $log, $q, $localStorage, $sessionStorage, pouchDB, config, utility) {
+angular.module('auth')
+  .service('AuthService', function AuthService($rootScope, $window, $log, $q, $localStorage, $sessionStorage, pouchDB, config, utility) {
     // seed asmCrypto PRNG for better security when creating random password salts
     $window.asmCrypto.random.seed($window.crypto.getRandomValues(new Uint8Array(128)));
 
@@ -124,7 +124,4 @@
           this.setCurrentUser(null);
         }.bind(this));
     };
-  }
-
-  angular.module('auth').service('AuthService', AuthService);
-}());
+  });

--- a/src/components/auth/auth.service.js
+++ b/src/components/auth/auth.service.js
@@ -93,7 +93,12 @@ angular.module('auth')
           var salt = $window.asmCrypto.bytes_to_hex($window.crypto.getRandomValues(new Uint8Array(16)));
           var iterations = 10;
           var derived = hash(password, salt, iterations);
-          var user = $window._.pick(response, ['_id', '_rev', 'name', 'roles']);
+          var user = {
+            _id: response._id,
+            _rev: response._rev,
+            name: response.name,
+            roles: response.roles
+          };
 
           $localStorage.auth[storageKey(username)] = {
             day: day(),

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,6 @@
     <script src="../bower_components/pouchdb/dist/pouchdb.js"></script>
     <script src="../bower_components/pouchdb-authentication/dist/pouchdb.authentication.js"></script>
     <script src="../bower_components/asmcrypto/asmcrypto.js"></script>
-    <script src="../bower_components/lodash/dist/lodash.js"></script>
     <script src="../bower_components/angular-pouchdb/dist/angular-pouchdb.js"></script>
     <script src="../bower_components/signature_pad/signature_pad.js"></script>
     <script src="../bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>


### PR DESCRIPTION
We're only using LoDash in auth.service (just pluck) and could easily drop it. However, there may be instances where using LoDash can streamline our codebase elsewhere.

We've had at least two discussions on this last year (see https://www.flowdock.com/app/ehealth-africa/dev?tags=es5vsunderscore), which resolved in our preference of (in order):

1. Use Angular's built-in helpers
2. Use native ES5
3. Use shorthand utilities (LoDash).

https://www.flowdock.com/app/ehealth-africa/dev/messages/472887