### PR TITLE
Bug/signature on tablet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: android
 android:
   components:
-    - android-19
+    - android-21
 node_js:
   - '0.10'
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ the [Keep a CHANGELOG][keep-a-changelog] format.
 ### Fixed
 
 - Asset linking in Cordova builds
+- Electronic signature on some devices (via Crosswalk)
 
 ### Removed
 

--- a/docs/build-enviroment.md
+++ b/docs/build-enviroment.md
@@ -26,7 +26,7 @@ The upstream-recommended way to update `npm` is:
 ## Android
 
 To be able to manually produce Android builds, you need to set up the Android
-SDK. We are targeting Android 4.4.2 (API 19).
+SDK.
 
 ### 1. Install the [Java JDK][jdk]
 
@@ -77,9 +77,8 @@ folder.
 [android-packages]: https://developer.android.com/sdk/installing/adding-packages.html
 
 The next bit is slightly confusing: a bunch of stuff is pre-selected, but *not
-preinstalled*. The manager pre-selects the most recent Android versions, but
-we're targeting Android 4.4.2. Therefore, deselect everything in the `Android
-5.0 folder`, and select everything in the `Android 4.4.2 (API 19)` folder.
+preinstalled*. Make sure the latest Android SDK Tools, platform-tools,
+build-tools and SDK platform is installed for `Android 5.0.1 (API 21)`.
 
 Click `Install n packages` to continue. Accept the license agreement and make
 some tea. Then you can finally continue the [build][] steps.

--- a/gulp/cordova/build.js
+++ b/gulp/cordova/build.js
@@ -7,6 +7,7 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var async = require('async');
 var cordova = require('cordova-lib').cordova;
+var crosswalk = require('crosswalk');
 var cordovaIcon = require('cordova-icon');
 
 var common = require('../../gulp/common');
@@ -47,7 +48,7 @@ function clean(done) {
 
 function cordovaAdd(cb) {
   gutil.log('Adding Android platform');
-  cordova.platform('add', 'android', cb);
+  cordova.platform('add', crosswalk.path, cb);
 }
 
 function generateIcons(cb) {

--- a/gulp/cordova/move.js
+++ b/gulp/cordova/move.js
@@ -11,7 +11,7 @@ var common = require('../../gulp/common');
 
 function formatAPKPaths(pkg, cb) {
   var apkPath = {
-    from: '../cordova/platforms/android/ant-build/CordovaApp',
+    from: '../cordova/platforms/android/out/DirectDelivery',
     to: 'build/' + pkg.name
   };
   if (argv.release || common.build.release) {

--- a/gulp/cordova/move.js
+++ b/gulp/cordova/move.js
@@ -11,7 +11,7 @@ var common = require('../../gulp/common');
 
 function formatAPKPaths(pkg, cb) {
   var apkPath = {
-    from: '../cordova/platforms/android/out/DirectDelivery',
+    from: '../cordova/platforms/android/bin/DirectDelivery',
     to: 'build/' + pkg.name
   };
   if (argv.release || common.build.release) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "cordova-lib": "^4.2.0",
     "couch-compile": "^1.2.0",
     "coveralls": "^2.11.2",
-    "crosswalk": "git+https://github.com/eHealthAfrica/crosswalk.git#f5b4a6696877f735d906b8a35b9224fdca52cdce",
+    "crosswalk": "git+https://github.com/eHealthAfrica/crosswalk.git#da5f7b790130063166ddb1c5a69aa522a9d14c81",
     "del": "~0.1.3",
     "eslint": "^0.13.0",
     "eslint-plugin-angular": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cordova-lib": "^4.2.0",
     "couch-compile": "^1.2.0",
     "coveralls": "^2.11.2",
+    "crosswalk": "git+https://github.com/eHealthAfrica/crosswalk.git#f5b4a6696877f735d906b8a35b9224fdca52cdce",
     "del": "~0.1.3",
     "eslint": "^0.13.0",
     "eslint-plugin-angular": "0.0.3",
@@ -51,11 +52,11 @@
     "merge-stream": "^0.1.6",
     "ng-config": "^1.0.0",
     "optimist": "^0.6.1",
+    "phantomjs": "^1.9.15",
     "protractor": "~1.4.0",
     "require-dir": "~0.1.0",
     "uglify-save-license": "~0.4.1",
-    "wiredep": "~2.2.0",
-    "phantomjs": "^1.9.15"
+    "wiredep": "~2.2.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
@tlvince,
changing 
```Javascript
 var apkPath = {
    from: '../cordova/platforms/android/out/DirectDelivery',
    to: 'build/' + pkg.name
  };
```

to 

```javascript
 var apkPath = {
    from: '../cordova/platforms/android/bin/DirectDelivery',
    to: 'build/' + pkg.name
  };
```

fixed the sym-link after build error. seems crosswalk.path is different from cordova ant path which means app-name-debug-aligned.apk does not exist at ..../out/ folder.

