### PR TITLE
feat(core): add conflict handling

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
     "angular-bootstrap": "~0.12.0",
     "angular-ui-router-tabs": "~1.2.0",
     "ng-signature-pad": "https://github.com/tlvince/ng-signature-pad.git#dafee158bc37a664c6d70feb8994201d230dccc6",
-    "ehealth-bootstrap": "https://github.com/eHealthAfrica/ehealth-bootstrap.git#0.0.5"
+    "ehealth-bootstrap": "https://github.com/eHealthAfrica/ehealth-bootstrap.git#0.0.5",
+    "pouch-resolve-conflicts": "~1.1.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.4",

--- a/src/components/core/core.service.js
+++ b/src/components/core/core.service.js
@@ -10,6 +10,7 @@ angular.module('core')
                                     utility, scheduleService, AuthService, $q, dbService) {
 
     var _this = this;
+    var isListeningForChanges = false;
     var isReplicationFromInProgress = false;
     var replicationTo;
     var inRetry = false;
@@ -76,6 +77,56 @@ angular.module('core')
           $rootScope.$emit(CORE_SYNC_DOWN.DENIED, {msg: err});
           onFailSync(err, replicateDown, driverEmail);
         });
+    }
+
+    function listenForConflicts() {
+      var db = pouchdbService.remote(config.db);
+
+      function resolveFun(remoteDoc, localDoc) {
+        if (!(remoteDoc.modifiedOn && localDoc.modifiedOn)) {
+          // Cannot resolve the conflict
+          return null;
+        }
+
+        var remoteDate = new Date(remoteDoc.modifiedOn).getTime();
+        var localDate = new Date(localDoc.modifiedOn).getTime();
+
+        if (isNaN(remoteDate) || isNaN(localDate)) {
+          // modifiedOn was not a valid data
+          // Cannot resolve the conflict
+          return null;
+        }
+
+        if (remoteDate > localDate) {
+          return remoteDoc;
+        }
+
+        return localDoc;
+      }
+
+      function changeHandler(change) {
+        if (!(change.doc && change.doc._conflicts)) {
+          return;
+        }
+        db.resolveConflicts(change.doc, resolveFun);
+      }
+
+      function toggleListening() {
+        isListeningForChanges = false;
+      }
+
+      var options = {
+        live: true,
+        /*eslint-disable camelcase */
+        include_docs: true,
+        /*eslint-enable camelcase */
+        conflicts: true
+      };
+
+      db.changes(options)
+        .on('change', changeHandler)
+        .on('complete', toggleListening)
+        .on('error', toggleListening);
     }
 
     _this.getSyncInProgress = function () {
@@ -220,6 +271,11 @@ angular.module('core')
       };
 
       if (!replicationTo) {
+        if (!isListeningForChanges) {
+          listenForConflicts();
+          isListeningForChanges = true;
+        }
+
         replicationTo = syncService.replicateToRemote(config.localDB, config.db, options);
         replicationTo
           .on('error', function (err) {

--- a/src/components/core/core.service.js
+++ b/src/components/core/core.service.js
@@ -5,9 +5,23 @@
  * @desc core service for app setup, daily sync and other core features of the app.
  */
 angular.module('core')
-  .service('coreService', function ($rootScope, syncService, config, pouchdbService, CORE_SYNC_DOWN,
-                                    SYNC_DAILY_DELIVERY, SYNC_DESIGN_DOC, $state, log, SYNC_STATUS,
-                                    utility, scheduleService, AuthService, $q, dbService) {
+  .service('coreService', function(
+    $rootScope,
+    syncService,
+    config,
+    pouchdbService,
+    CORE_SYNC_DOWN,
+    SYNC_DAILY_DELIVERY,
+    SYNC_DESIGN_DOC,
+    $state,
+    log,
+    SYNC_STATUS,
+    utility,
+    scheduleService,
+    AuthService,
+    $q,
+    dbService
+  ) {
 
     var _this = this;
     var isListeningForChanges = false;

--- a/src/components/db/db.config.js
+++ b/src/components/db/db.config.js
@@ -1,0 +1,7 @@
+'use strict';
+
+angular.module('db')
+  .config(function(POUCHDB_METHODS) {
+    // Register jo/pouch-resolve-conflicts with angular-pouchdb
+    POUCHDB_METHODS.resolveConflicts = 'qify';
+  });

--- a/src/components/delivery/delivery.service.js
+++ b/src/components/delivery/delivery.service.js
@@ -180,4 +180,27 @@ angular.module('delivery')
       }
     };
 
+    _this.isDelivered = function (deliveryRound) {
+      if (!deliveryRound.facilityRounds) {
+        return false;
+      }
+
+      // Treat deliveries with any of these statuses as delivered
+      var deliveredStatuses = [
+        DELIVERY_STATUS.SUCCESS_FIRST,
+        DELIVERY_STATUS.SUCCESS_SECOND,
+        DELIVERY_STATUS.CANCELED_CCE,
+        DELIVERY_STATUS.CANCELED_OTHER,
+        DELIVERY_STATUS.CANCELED_STAFF,
+        DELIVERY_STATUS.FAILED_CCE,
+        DELIVERY_STATUS.FAILED_STAFF,
+        DELIVERY_STATUS.FAILED_OTHER
+      ];
+
+      function isDelivered(facilityRound) {
+        return deliveredStatuses.indexOf(facilityRound.status) !== -1;
+      }
+
+      return deliveryRound.facilityRounds.every(isDelivered);
+    };
   });

--- a/src/components/log/messages/info.constants.js
+++ b/src/components/log/messages/info.constants.js
@@ -9,5 +9,9 @@ angular.module('log')
     dailyDeliverySaved: {
       title: 'Daily delivery saved',
       message: 'Daily delivery saved so you won\'t lose changes'
+    },
+    conflictResolved: {
+      title: 'Conflict resolved',
+      message: 'A record had been changed both on the server and on your local device since the last sync. This has been automatically resolved.'
     }
   });

--- a/src/components/sync/conflicts-doctype-whitelist.constant.js
+++ b/src/components/sync/conflicts-doctype-whitelist.constant.js
@@ -2,6 +2,7 @@
 
 angular.module('sync')
   .constant('CONFLICTS_DOCTYPE_WHITELIST', [
+    'kpi',
     'dailyDelivery',
     'deliveryRound'
   ]);

--- a/src/components/sync/conflicts-doctype-whitelist.constant.js
+++ b/src/components/sync/conflicts-doctype-whitelist.constant.js
@@ -1,0 +1,7 @@
+'use strict';
+
+angular.module('sync')
+  .constant('CONFLICTS_DOCTYPE_WHITELIST', [
+    'dailyDelivery',
+    'deliveryRound'
+  ]);

--- a/src/components/sync/conflicts.service.js
+++ b/src/components/sync/conflicts.service.js
@@ -29,7 +29,7 @@ angular.module('sync')
         var localDate = new Date(localDoc.modifiedOn).getTime();
 
         if (isNaN(remoteDate) || isNaN(localDate)) {
-          // modifiedOn was not a valid data
+          // modifiedOn was not a valid date
           // Cannot resolve the conflict
           return null;
         }

--- a/src/components/sync/conflicts.service.js
+++ b/src/components/sync/conflicts.service.js
@@ -2,6 +2,7 @@
 
 angular.module('sync')
   .service('conflictsService', function(
+    log,
     config,
     pouchdbService,
     CONFLICTS_DOCTYPE_WHITELIST
@@ -15,6 +16,7 @@ angular.module('sync')
         // Remote should always win for doc types not in the whitelist, e.g.
         // those that should not be modified on the phone.
         if (CONFLICTS_DOCTYPE_WHITELIST.indexOf(remoteDoc.doc_type) === -1) {
+          log.info('conflictResolved');
           return remoteDoc;
         }
 
@@ -33,9 +35,11 @@ angular.module('sync')
         }
 
         if (remoteDate > localDate) {
+          log.info('conflictResolved');
           return remoteDoc;
         }
 
+        log.info('conflictResolved');
         return localDoc;
       }
 

--- a/src/components/sync/conflicts.service.js
+++ b/src/components/sync/conflicts.service.js
@@ -5,6 +5,7 @@ angular.module('sync')
     log,
     config,
     pouchdbService,
+    deliveryService,
     CONFLICTS_DOCTYPE_WHITELIST
   ) {
     var listening = false;
@@ -23,6 +24,13 @@ angular.module('sync')
         if (!(remoteDoc.modifiedOn && localDoc.modifiedOn)) {
           // Cannot resolve the conflict
           return null;
+        }
+
+        if (localDoc.doc_type === 'dailyDelivery') {
+          if (deliveryService.isDelivered(localDoc)) {
+            log.info('conflictResolved');
+            return localDoc;
+          }
         }
 
         var remoteDate = new Date(remoteDoc.modifiedOn).getTime();

--- a/src/components/sync/conflicts.service.js
+++ b/src/components/sync/conflicts.service.js
@@ -1,0 +1,68 @@
+'use strict';
+
+angular.module('sync')
+  .service('conflictsService', function(
+    config,
+    pouchdbService
+  ) {
+    var listening = false;
+
+    function conflictsListener() {
+      var db = pouchdbService.remote(config.db);
+
+      function resolveFun(remoteDoc, localDoc) {
+        if (!(remoteDoc.modifiedOn && localDoc.modifiedOn)) {
+          // Cannot resolve the conflict
+          return null;
+        }
+
+        var remoteDate = new Date(remoteDoc.modifiedOn).getTime();
+        var localDate = new Date(localDoc.modifiedOn).getTime();
+
+        if (isNaN(remoteDate) || isNaN(localDate)) {
+          // modifiedOn was not a valid data
+          // Cannot resolve the conflict
+          return null;
+        }
+
+        if (remoteDate > localDate) {
+          return remoteDoc;
+        }
+
+        return localDoc;
+      }
+
+      function changeHandler(change) {
+        if (!(change.doc && change.doc._conflicts)) {
+          return;
+        }
+        db.resolveConflicts(change.doc, resolveFun);
+      }
+
+      function toggleListening() {
+        listening = false;
+      }
+
+      var options = {
+        live: true,
+        /*eslint-disable camelcase */
+        include_docs: true,
+        /*eslint-enable camelcase */
+        conflicts: true
+      };
+
+      db.changes(options)
+        .on('change', changeHandler)
+        .on('complete', toggleListening)
+        .on('error', toggleListening);
+
+      listening = true;
+    }
+
+    this.maybeListenForConflicts = function() {
+      if (listening) {
+        return;
+      }
+      conflictsListener();
+    };
+  });

--- a/src/components/sync/conflicts.service.js
+++ b/src/components/sync/conflicts.service.js
@@ -21,16 +21,16 @@ angular.module('sync')
           return remoteDoc;
         }
 
-        if (!(remoteDoc.modifiedOn && localDoc.modifiedOn)) {
-          // Cannot resolve the conflict
-          return null;
-        }
-
         if (localDoc.doc_type === 'dailyDelivery') {
           if (deliveryService.isDelivered(localDoc)) {
             log.info('conflictResolved');
             return localDoc;
           }
+        }
+
+        if (!(remoteDoc.modifiedOn && localDoc.modifiedOn)) {
+          // Cannot resolve the conflict
+          return null;
         }
 
         var remoteDate = new Date(remoteDoc.modifiedOn).getTime();

--- a/src/components/sync/conflicts.service.spec.js
+++ b/src/components/sync/conflicts.service.spec.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global beforeEach, inject, module, it, expect, describe */
+/* global beforeEach, inject, module, it, expect, describe, spyOn */
 
 describe('conflictsService', function () {
   beforeEach(module('sync'));
@@ -32,11 +32,26 @@ describe('conflictsService', function () {
               on: on
             };
           },
-          resolveConflicts: resolveConflictsFun
+          resolveConflicts: resolveConflictsFun || angular.noop
         };
       }
     };
   }
+
+  it('should not try to listen for changes twice', function() {
+    var mock = dbMockFactory();
+    spyOn(mock, 'create').and.callThrough();
+
+    module(function($provide) {
+      $provide.value('pouchdbService', mock);
+    });
+
+    inject(function(conflictsService) {
+      conflictsService.maybeListenForConflicts();
+      conflictsService.maybeListenForConflicts();
+      expect(mock.create.calls.count()).toEqual(1);
+    });
+  });
 
   it('should return remote doc if not in whitelist', function() {
     var actual;

--- a/src/components/sync/conflicts.service.spec.js
+++ b/src/components/sync/conflicts.service.spec.js
@@ -74,4 +74,26 @@ describe('conflictsService', function () {
       expect(actual.name).toBe('gil');
     });
   });
+
+  it('should abort if modifiedOn is missing', function() {
+    var actual;
+
+    function resolveConflicts(doc, resolveFun) {
+      doc = {
+        /*eslint-disable camelcase */
+        doc_type: 'dailyDelivery'
+        /*eslint-enable camelcase */
+      };
+      actual = resolveFun(doc, doc);
+    }
+
+    module(function($provide) {
+      $provide.value('pouchdbService', dbMockFactory(resolveConflicts));
+    });
+
+    inject(function(conflictsService) {
+      conflictsService.maybeListenForConflicts();
+      expect(actual).toBe(null);
+    });
+  });
 });

--- a/src/components/sync/conflicts.service.spec.js
+++ b/src/components/sync/conflicts.service.spec.js
@@ -159,7 +159,7 @@ describe('conflictsService', function () {
       doc_type: 'dailyDelivery',
       /*eslint-enable camelcase */
       modifiedOn: '2099-11-04T19:42:22.823Z'
-    }
+    };
 
     function resolveConflicts(doc, resolveFun) {
       var localDoc = {
@@ -167,7 +167,7 @@ describe('conflictsService', function () {
         doc_type: 'dailyDelivery',
         /*eslint-enable camelcase */
         modifiedOn: '2000-11-04T19:42:22.823Z'
-      }
+      };
       actual = resolveFun(remoteDoc, localDoc);
     }
 
@@ -178,6 +178,35 @@ describe('conflictsService', function () {
     inject(function(conflictsService) {
       conflictsService.maybeListenForConflicts();
       expect(actual).toEqual(remoteDoc);
+    });
+  });
+
+  it('should mark local the winner if newer', function() {
+    var actual;
+    var localDoc = {
+      /*eslint-disable camelcase */
+      doc_type: 'dailyDelivery',
+      /*eslint-enable camelcase */
+      modifiedOn: '2099-11-04T19:42:22.823Z'
+    };
+
+    function resolveConflicts(doc, resolveFun) {
+      var remoteDoc = {
+        /*eslint-disable camelcase */
+        doc_type: 'dailyDelivery',
+        /*eslint-enable camelcase */
+        modifiedOn: '2000-11-04T19:42:22.823Z'
+      };
+      actual = resolveFun(remoteDoc, localDoc);
+    }
+
+    module(function($provide) {
+      $provide.value('pouchdbService', dbMockFactory(resolveConflicts));
+    });
+
+    inject(function(conflictsService) {
+      conflictsService.maybeListenForConflicts();
+      expect(actual).toEqual(localDoc);
     });
   });
 });

--- a/src/components/sync/conflicts.service.spec.js
+++ b/src/components/sync/conflicts.service.spec.js
@@ -96,4 +96,36 @@ describe('conflictsService', function () {
       expect(actual).toBe(null);
     });
   });
+
+  it('should make local win if its a delivered delivery doc', function() {
+    var actual;
+    var localDoc = {
+      /*eslint-disable camelcase */
+      doc_type: 'dailyDelivery',
+      /*eslint-enable camelcase */
+      facilityRounds: [
+        {
+          status: 'Success: 1st Attempt'
+        }
+      ]
+    };
+
+    function resolveConflicts(doc, resolveFun) {
+      var remoteDoc = {
+        /*eslint-disable camelcase */
+        doc_type: 'deliveryRound'
+        /*eslint-enable camelcase */
+      };
+      actual = resolveFun(remoteDoc, localDoc);
+    }
+
+    module(function($provide) {
+      $provide.value('pouchdbService', dbMockFactory(resolveConflicts));
+    });
+
+    inject(function(conflictsService) {
+      conflictsService.maybeListenForConflicts();
+      expect(actual).toEqual(localDoc);
+    });
+  });
 });

--- a/src/components/sync/conflicts.service.spec.js
+++ b/src/components/sync/conflicts.service.spec.js
@@ -1,0 +1,62 @@
+'use strict';
+/* global beforeEach, inject, module, it, expect, describe */
+
+describe('conflictsService', function () {
+  beforeEach(module('sync'));
+
+  function dbMockFactory(resolveConflictsFun) {
+    var change = {
+      doc: {
+        _conflicts: [],
+        /*eslint-disable camelcase */
+        doc_type: 'mock'
+        /*eslint-enable camelcase */
+      }
+    };
+
+    function on(event, fun) {
+      if (event === 'change') {
+        fun(change);
+      }
+      return {
+        on: on
+      };
+    }
+
+    return {
+      create: angular.noop,
+      remote: function() {
+        return {
+          changes: function() {
+            return {
+              on: on
+            };
+          },
+          resolveConflicts: resolveConflictsFun
+        };
+      }
+    };
+  }
+
+  it('should return remote doc if not in whitelist', function() {
+    var actual;
+
+    function resolveConflicts(doc, resolveFun) {
+      var leftDoc = {
+        name: 'gil'
+      };
+      var rightDoc = {
+      };
+      actual = resolveFun(leftDoc, rightDoc);
+    }
+
+    module(function($provide) {
+      $provide.value('pouchdbService', dbMockFactory(resolveConflicts));
+    });
+
+    inject(function(conflictsService) {
+      conflictsService.maybeListenForConflicts();
+      expect(actual.name).toBe('gil');
+    });
+  });
+});

--- a/src/components/sync/conflicts.service.spec.js
+++ b/src/components/sync/conflicts.service.spec.js
@@ -151,4 +151,33 @@ describe('conflictsService', function () {
       expect(actual).toBe(null);
     });
   });
+
+  it('should mark remote the winner if its newer', function() {
+    var actual;
+    var remoteDoc = {
+      /*eslint-disable camelcase */
+      doc_type: 'dailyDelivery',
+      /*eslint-enable camelcase */
+      modifiedOn: '2099-11-04T19:42:22.823Z'
+    }
+
+    function resolveConflicts(doc, resolveFun) {
+      var localDoc = {
+        /*eslint-disable camelcase */
+        doc_type: 'dailyDelivery',
+        /*eslint-enable camelcase */
+        modifiedOn: '2000-11-04T19:42:22.823Z'
+      }
+      actual = resolveFun(remoteDoc, localDoc);
+    }
+
+    module(function($provide) {
+      $provide.value('pouchdbService', dbMockFactory(resolveConflicts));
+    });
+
+    inject(function(conflictsService) {
+      conflictsService.maybeListenForConflicts();
+      expect(actual).toEqual(remoteDoc);
+    });
+  });
 });

--- a/src/components/sync/conflicts.service.spec.js
+++ b/src/components/sync/conflicts.service.spec.js
@@ -128,4 +128,27 @@ describe('conflictsService', function () {
       expect(actual).toEqual(localDoc);
     });
   });
+
+  it('should abort on malformed modifiedOn dates', function() {
+    var actual;
+
+    function resolveConflicts(doc, resolveFun) {
+      doc = {
+        /*eslint-disable camelcase */
+        doc_type: 'dailyDelivery',
+        /*eslint-enable camelcase */
+        modifiedOn: 'foo'
+      };
+      actual = resolveFun(doc, doc);
+    }
+
+    module(function($provide) {
+      $provide.value('pouchdbService', dbMockFactory(resolveConflicts));
+    });
+
+    inject(function(conflictsService) {
+      conflictsService.maybeListenForConflicts();
+      expect(actual).toBe(null);
+    });
+  });
 });

--- a/src/components/sync/sync.module.js
+++ b/src/components/sync/sync.module.js
@@ -7,5 +7,6 @@ angular.module('sync', [
   'db',
   'config',
   'utility',
-  'log'
+  'log',
+  'delivery'
 ]);

--- a/src/components/sync/sync.module.js
+++ b/src/components/sync/sync.module.js
@@ -6,5 +6,6 @@
 angular.module('sync', [
   'db',
   'config',
-  'utility'
+  'utility',
+  'log'
 ]);

--- a/src/index.html
+++ b/src/index.html
@@ -84,6 +84,7 @@
     <script src="components/sync/sync.module.js"></script>
     <script src="components/sync/sync.service.js"></script>
     <script src="components/sync/sync.constant.js"></script>
+    <script src="components/sync/conflicts.service.js"></script>
     <script src="components/schedules/schedules.module.js"></script>
     <script src="components/schedules/schedules.states.js"></script>
     <script src="components/schedules/schedule.service.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -85,6 +85,7 @@
     <script src="components/sync/sync.service.js"></script>
     <script src="components/sync/sync.constant.js"></script>
     <script src="components/sync/conflicts.service.js"></script>
+    <script src="components/sync/conflicts-doctype-whitelist.constant.js"></script>
     <script src="components/schedules/schedules.module.js"></script>
     <script src="components/schedules/schedules.states.js"></script>
     <script src="components/schedules/schedule.service.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -39,6 +39,7 @@
     <script src="../bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
     <script src="../bower_components/angular-ui-router-tabs/src/ui-router-tabs.js"></script>
     <script src="../bower_components/ng-signature-pad/dist/ng-signature-pad.js"></script>
+    <script src="../bower_components/pouch-resolve-conflicts/dist/pouch-resolve-conflicts.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 
@@ -80,35 +81,36 @@
     <script src="components/utility/utility.service.js"></script>
     <script src="components/utility/pouchdb-utility.module.js"></script>
     <script src="components/utility/pouchdb-utility.service.js"></script>
-    <script src="components/core/core.module.js"></script>
-    <script src="components/core/core.service.js"></script>
     <script src="components/sync/sync.module.js"></script>
     <script src="components/sync/sync.service.js"></script>
     <script src="components/sync/sync.constant.js"></script>
     <script src="components/schedules/schedules.module.js"></script>
     <script src="components/schedules/schedules.states.js"></script>
     <script src="components/schedules/schedule.service.js"></script>
-    <script src="components/navbar/navbar.module.js"></script>
-    <script src="components/navbar/navbar.service.js"></script>
-    <script src="components/navbar/navbar.controller.js"></script>
     <script src="components/packing-table/packing-table.module.js"></script>
     <script src="components/packing-table/storage-attributes.constant.js"></script>
     <script src="components/packing-table/packing-table.service.js"></script>
     <script src="components/packing-table/packing-table.controller.js"></script>
     <script src="components/packing-table/legend.service.js"></script>
+    <script src="components/navbar/navbar.module.js"></script>
+    <script src="components/navbar/navbar.service.js"></script>
+    <script src="components/navbar/navbar.controller.js"></script>
     <script src="components/log/log.service.js"></script>
     <script src="components/loading-screen/loading-screen.module.js"></script>
     <script src="components/loading-screen/loading-screen.state.js"></script>
     <script src="components/loading-screen/loading-screen.controller.js"></script>
+    <script src="components/footer/footer.module.js"></script>
+    <script src="components/footer/footer.controller.js"></script>
     <script src="components/delivery/delivery.states.js"></script>
     <script src="components/delivery/delivery.service.js"></script>
     <script src="components/delivery/delivery.controller.js"></script>
     <script src="components/delivery/delivery.constant.js"></script>
-    <script src="components/footer/footer.module.js"></script>
-    <script src="components/footer/footer.controller.js"></script>
     <script src="components/db/db.module.js"></script>
     <script src="components/db/db.service.js"></script>
     <script src="components/db/db.pouchdb.service.js"></script>
+    <script src="components/db/db.config.js"></script>
+    <script src="components/core/core.module.js"></script>
+    <script src="components/core/core.service.js"></script>
     <script src="components/auth/auth.module.js"></script>
     <script src="components/auth/auth.service.js"></script>
     <script src="components/auth/auth.config.js"></script>


### PR DESCRIPTION
Recursively declare the remote doc the winner if it's newer.

How to test this:

1. Make sure the app is not running
2. In CouchDB, set the OPV packed quantity of a daily delivery doc to 999 and
   set the modified date to a future date (e.g. an hour ahead)
3. Save the doc
4. Kill CouchDB
5. Load the app
6. Set the packed quantity of OPV to 1
7. Save the doc
8. Close the app
9. Start up CouchDB
10. Start up the app

After sync, OPV packed quantity should be 999.

Closes #255.