### PR TITLE
chore: use new staging DB

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -10,7 +10,7 @@
     </feature>
     <content src="index.html" />
     <access origin="http://localhost:5984/*" />
-    <access origin="https://dev.couchdb.ebola.eocng.org/*" />
+    <access origin="https://dd-db-dev.ehealth.org.ng/*" />
     <access origin="https://couchdb.ebola.eocng.org/*" />
     <preference name="xwalkVersion" value="14+" />
     <preference name="xwalkCommandLine" value="--disable-pull-to-refresh-effect" />

--- a/config/stage.json
+++ b/config/stage.json
@@ -1,4 +1,4 @@
 {
-  "db": "https://dev.couchdb.ebola.eocng.org/deliveries",
+  "db": "https://dd-db-dev.ehealth.org.ng/deliveries",
   "trackingID": "UA-52016752-9"
 }

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
     <title>Direct Delivery</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:3000; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws://localhost:3000 https://couchdb.ebola.eocng.org https://dev.couchdb.ebola.eocng.org http://localhost:5984">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:3000; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws://localhost:3000 https://couchdb.ebola.eocng.org https://dd-db-dev.ehealth.org.ng http://localhost:5984">
     <!-- build:css({.tmp/serve,src}) styles/vendor.css -->
     <!-- bower:css -->
     <!-- run `gulp inject` to automatically populate bower styles dependencies -->


### PR DESCRIPTION
NB, we also had https://github.com/eHealthAfrica/direct-delivery/issues/279. For that, we need a proper stage server (we only have dev and prod right now). Is `dev.couchdb.ebola.eocng.org` deprecated?